### PR TITLE
Modify USB Descriptor Product Name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_compile_options(
 add_definitions(-DVERBOSE)
 # add_definitions(-DLAUNCH)
 # add_definitions(-DSIM)
+add_definitions(-DUSBD_PRODUCT="FSW Pico")
 
 # Add source files from src/
 set(SOURCES


### PR DESCRIPTION
### Summary
Changed USB Descriptor Product Name from "Pico" to "FSW Pico" for Fill Station Serial Port Symlinking. We needed to differentiate between rocket pico and RATS pico.

### Testing
Uploaded code, plugged into fill station along with RATS board, and confirmed udev rule applied to each correctly.

### Documentation
Documented in https://confluence.cornell.edu/display/crt/Fill+Station+udev+Rules+for+Assigning+Serial+Ports

